### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/Knight1/tsumami/security/code-scanning/1](https://github.com/Knight1/tsumami/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow only builds and tests the code, it only requires `contents: read` permissions. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
